### PR TITLE
FIX pagination when there are multiple pages

### DIFF
--- a/_includes/pagination.html
+++ b/_includes/pagination.html
@@ -3,6 +3,6 @@
     <a href="..{{ paginator.previous_page_path }}" class="previous"><i class="fa fa-angle-left" aria-hidden="true"></i> Previous</a>
   {% endif %}
   {% if paginator.next_page %}
-    <a href=".{{ paginator.next_page_path }}" class="next">Next <i class="fa fa-angle-right" aria-hidden="true"></i></a>
+    <a href="..{{ paginator.next_page_path }}" class="next">Next <i class="fa fa-angle-right" aria-hidden="true"></i></a>
   {% endif %}
 </div>


### PR DESCRIPTION
Current behavior: 
When you click "next" from page2, the url will be redirected to: http://localhost:4000/page2/page3
After the fix:
When you click "next" from page2, the url will be redirected to: http://localhost:4000/page3